### PR TITLE
[FLINK-14941][hbase] The AbstractTableInputFormat#nextRecord in hbase connector will handle the same rowkey twice once encountered any exception

### DIFF
--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/addons/hbase/AbstractTableInputFormat.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/addons/hbase/AbstractTableInputFormat.java
@@ -137,7 +137,7 @@ public abstract class AbstractTableInputFormat<T> extends RichInputFormat<T, Tab
 			resultScanner.close();
 			//workaround for timeout on scan
 			LOG.warn("Error after scan of " + scannedRows + " rows. Retry with a new scanner...", e);
-			scan.setStartRow(currentRow);
+			scan.withStartRow(currentRow, false);
 			resultScanner = table.getScanner(scan);
 			Result res = resultScanner.next();
 			if (res != null) {


### PR DESCRIPTION
10314