### PR TITLE
[FLINK-14021][table-planner][table-planner-blink] Add rules to push down the Python ScalarFunctions contained in the join condition of Correlate node

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -257,7 +257,6 @@ object FlinkBatchRuleSets {
 
     // join rules
     FlinkJoinPushExpressionsRule.INSTANCE,
-    SimplifyJoinConditionRule.INSTANCE,
 
     // remove union with only a single child
     UnionEliminatorRule.INSTANCE,
@@ -359,6 +358,9 @@ object FlinkBatchRuleSets {
     CalcSnapshotTransposeRule.INSTANCE,
     // Rule that splits python ScalarFunctions from join conditions
     SplitPythonConditionFromJoinRule.INSTANCE,
+    // Rule that splits python ScalarFunctions from
+    // java/scala ScalarFunctions in correlate conditions
+    SplitPythonConditionFromCorrelateRule.INSTANCE,
     // merge calc after calc transpose
     FlinkCalcMergeRule.INSTANCE,
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions
@@ -414,13 +416,5 @@ object FlinkBatchRuleSets {
     BatchExecCorrelateRule.INSTANCE,
     // sink
     BatchExecSinkRule.INSTANCE
-  )
-
-  /**
-    * RuleSet to optimize plans after batch exec execution.
-    */
-  val PHYSICAL_REWRITE: RuleSet = RuleSets.ofList(
-    EnforceLocalHashAggRule.INSTANCE,
-    EnforceLocalSortAggRule.INSTANCE
   )
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -236,7 +236,6 @@ object FlinkStreamRuleSets {
 
     // join rules
     FlinkJoinPushExpressionsRule.INSTANCE,
-    SimplifyJoinConditionRule.INSTANCE,
 
     // remove union with only a single child
     UnionEliminatorRule.INSTANCE,
@@ -339,6 +338,9 @@ object FlinkStreamRuleSets {
     CalcSnapshotTransposeRule.INSTANCE,
     // Rule that splits python ScalarFunctions from join conditions
     SplitPythonConditionFromJoinRule.INSTANCE,
+    // Rule that splits python ScalarFunctions from
+    // java/scala ScalarFunctions in correlate conditions
+    SplitPythonConditionFromCorrelateRule.INSTANCE,
     // merge calc after calc transpose
     FlinkCalcMergeRule.INSTANCE,
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromCorrelateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromCorrelateRule.scala
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical
+
+import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.plan.hep.HepRelVertex
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelOptUtil}
+import org.apache.calcite.rel.core.JoinRelType
+import org.apache.calcite.rex._
+import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalCorrelate, FlinkLogicalRel}
+import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
+import org.apache.flink.table.planner.plan.utils.RexDefaultVisitor
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+/**
+  * Rule will split a [[FlinkLogicalCalc]] which is the upstream of a [[FlinkLogicalCorrelate]]
+  * and contains Python Functions in condition into two [[FlinkLogicalCalc]]s. One of the
+  * [[FlinkLogicalCalc]] without python function condition is the upstream of the
+  * [[FlinkLogicalCorrelate]], but the other [[[FlinkLogicalCalc]] with python function conditions
+  * is the downstream of the [[FlinkLogicalCorrelate]]. Currently, only inner join is supported.
+  *
+  * After this rule is applied, there will be no Python Functions in the condition of the upstream
+  * [[FlinkLogicalCalc]].
+  */
+class SplitPythonConditionFromCorrelateRule
+  extends RelOptRule(
+    operand(
+      classOf[FlinkLogicalCorrelate],
+      operand(classOf[FlinkLogicalRel], any),
+      operand(classOf[FlinkLogicalCalc], any)),
+    "SplitPythonConditionFromCorrelateRule") {
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val correlate: FlinkLogicalCorrelate = call.rel(0).asInstanceOf[FlinkLogicalCorrelate]
+    val right: FlinkLogicalCalc = call.rel(2).asInstanceOf[FlinkLogicalCalc]
+    val joinType: JoinRelType = correlate.getJoinType
+    joinType == JoinRelType.INNER && containsPythonFunctionCondition(right)
+  }
+
+  private def containsPythonFunctionCondition(calc: FlinkLogicalCalc): Boolean = {
+    val program = calc.getProgram
+    val conditionExistPythonFunction = Option(program.getCondition)
+      .map(program.expandLocalRef)
+      .exists(containsPythonCall)
+    if (conditionExistPythonFunction) {
+      true
+    } else {
+      val child = calc.getInput.asInstanceOf[HepRelVertex].getCurrentRel
+      child match {
+        case calc: FlinkLogicalCalc => containsPythonFunctionCondition(calc)
+        case _ => false
+      }
+    }
+  }
+
+  private def getMergedCalc(calc: FlinkLogicalCalc): FlinkLogicalCalc = {
+    val child = calc.getInput.asInstanceOf[HepRelVertex].getCurrentRel
+    child match {
+      case logicalCalc: FlinkLogicalCalc =>
+        val bottomCalc = getMergedCalc(logicalCalc)
+        val topCalc = calc
+        val topProgram: RexProgram = topCalc.getProgram
+        val mergedProgram: RexProgram = RexProgramBuilder
+          .mergePrograms(
+            topCalc.getProgram,
+            bottomCalc.getProgram,
+            topCalc.getCluster.getRexBuilder)
+        assert(mergedProgram.getOutputRowType eq topProgram.getOutputRowType)
+        topCalc.copy(topCalc.getTraitSet, bottomCalc.getInput, mergedProgram)
+          .asInstanceOf[FlinkLogicalCalc]
+      case _ =>
+        calc
+    }
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val correlate: FlinkLogicalCorrelate = call.rel(0).asInstanceOf[FlinkLogicalCorrelate]
+    val right: FlinkLogicalCalc = call.rel(2).asInstanceOf[FlinkLogicalCalc]
+    val rexBuilder = call.builder().getRexBuilder
+    val mergedCalc = getMergedCalc(right)
+    val mergedCalcProgram = mergedCalc.getProgram
+    val input = mergedCalc.getInput
+
+    val correlateFilters = RelOptUtil
+      .conjunctions(mergedCalcProgram.getCondition)
+      .map(_.asInstanceOf[RexLocalRef])
+      .map(mergedCalcProgram.expandLocalRef)
+
+    val remainingFilters = correlateFilters.filter(!containsPythonCall(_))
+
+    val bottomCalcCondition = RexUtil.composeConjunction(rexBuilder, remainingFilters)
+
+    val newBottomCalc = new FlinkLogicalCalc(
+      mergedCalc.getCluster,
+      mergedCalc.getTraitSet,
+      input,
+      RexProgram.create(
+        input.getRowType,
+        mergedCalcProgram.getProjectList,
+        bottomCalcCondition,
+        mergedCalc.getRowType,
+        rexBuilder))
+
+    val newCorrelate = new FlinkLogicalCorrelate(
+      correlate.getCluster,
+      correlate.getTraitSet,
+      correlate.getLeft,
+      newBottomCalc,
+      correlate.getCorrelationId,
+      correlate.getRequiredColumns,
+      correlate.getJoinType)
+
+    val inputRefRewriter = new InputRefRewriter(
+      correlate.getRowType.getFieldCount - mergedCalc.getRowType.getFieldCount)
+
+    val pythonFilters = correlateFilters
+      .map(_.accept(inputRefRewriter))
+      .filter(containsPythonCall)
+
+    val topCalcCondition = RexUtil.composeConjunction(rexBuilder, pythonFilters)
+
+    val rexProgram = new RexProgramBuilder(newCorrelate.getRowType, rexBuilder).getProgram
+    val newTopCalc = new FlinkLogicalCalc(
+      newCorrelate.getCluster,
+      newCorrelate.getTraitSet,
+      newCorrelate,
+      RexProgram.create(
+        newCorrelate.getRowType,
+        rexProgram.getExprList,
+        topCalcCondition,
+        newCorrelate.getRowType,
+        rexBuilder))
+
+    call.transformTo(newTopCalc)
+  }
+}
+
+/**
+  * Because the inputRef is from the upstream calc node of the correlate node,
+  * so after the inputRef is pushed to the downstream calc node of the correlate
+  * node, the inputRef need to rewrite the index.
+  *
+  * @param offset the start offset of the inputRef in the downstream calc.
+  */
+private class InputRefRewriter(offset: Int)
+  extends RexDefaultVisitor[RexNode] {
+
+  override def visitInputRef(inputRef: RexInputRef): RexNode = {
+    new RexInputRef(inputRef.getIndex + offset, inputRef.getType)
+  }
+
+  override def visitCall(call: RexCall): RexNode = {
+    call.clone(call.getType, call.getOperands.asScala.map(_.accept(this)))
+  }
+
+  override def visitNode(rexNode: RexNode): RexNode = rexNode
+}
+
+object SplitPythonConditionFromCorrelateRule {
+  val INSTANCE: SplitPythonConditionFromCorrelateRule = new SplitPythonConditionFromCorrelateRule
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromCorrelateRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromCorrelateRuleTest.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testPythonFunctionInCorrelateCondition">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, c, s, l FROM MyTable, LATERAL TABLE(func(c)) AS T(s, l) WHERE l = a and c = s and pyFunc(l, l) = 2]]>
+
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], s=[$3], l=[$4])
++- LogicalFilter(condition=[AND(=($4, $0), =($2, $3), =(pyFunc($4, $4), 2))])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+      +- LogicalTableFunctionScan(invocation=[func($cor0.c)], rowType=[RecordType(VARCHAR(2147483647) f0, INTEGER f1)], elementType=[class [Ljava.lang.Object;])
+]]>
+
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, b, c, f0, f1], where=[AND(=(f1, a), =(c, f0), =(f00, 2))])
++- FlinkLogicalCalc(select=[a, b, c, f0, f1, pyFunc(f1, f1) AS f00])
+   +- FlinkLogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+      :- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+      +- FlinkLogicalTableFunctionScan(invocation=[func($cor0.c)], rowType=[RecordType(VARCHAR(2147483647) f0, INTEGER f1)], elementType=[class [Ljava.lang.Object;])
+]]>
+
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromCorrelateRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromCorrelateRuleTest.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical
+
+import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.planner.plan.nodes.FlinkConventions
+import org.apache.flink.table.planner.plan.optimize.program._
+import org.apache.flink.table.planner.plan.rules.FlinkBatchRuleSets
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.PythonScalarFunction
+import org.apache.flink.table.planner.utils.{TableFunc2, TableTestBase}
+import org.junit.{Before, Test}
+
+/**
+  * Test for [[SplitPythonConditionFromCorrelateRule]].
+  */
+class SplitPythonConditionFromCorrelateRuleTest extends TableTestBase {
+
+  private val util = batchTestUtil()
+
+  @Before
+  def setup(): Unit = {
+    val programs = new FlinkChainedProgram[BatchOptimizeContext]()
+    programs.addLast(
+      "logical",
+      FlinkVolcanoProgramBuilder.newBuilder
+        .add(FlinkBatchRuleSets.LOGICAL_OPT_RULES)
+        .setRequiredOutputTraits(Array(FlinkConventions.LOGICAL))
+        .build())
+    programs.addLast(
+      "logical_rewrite",
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(FlinkBatchRuleSets.LOGICAL_REWRITE)
+        .build())
+    util.replaceBatchProgram(programs)
+
+    util.addTableSource[(Int, Int, String)]("MyTable", 'a, 'b, 'c)
+    util.addFunction("func", new TableFunc2)
+    util.addFunction("pyFunc", new PythonScalarFunction("pyFunc"))
+  }
+
+  @Test
+  def testPythonFunctionInCorrelateCondition(): Unit = {
+    val sqlQuery = "SELECT a, b, c, s, l FROM MyTable, LATERAL TABLE(func(c)) AS T(s, l) " +
+      "WHERE l = a and c = s and pyFunc(l, l) = 2"
+    util.verifyPlan(sqlQuery)
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -149,6 +149,9 @@ object FlinkRuleSets {
   val LOGICAL_REWRITE_RULES: RuleSet = RuleSets.ofList(
     // Rule that splits python ScalarFunctions from join conditions
     SplitPythonConditionFromJoinRule.INSTANCE,
+    // Rule that splits python ScalarFunctions from
+    // java/scala ScalarFunctions in correlate conditions
+    SplitPythonConditionFromCorrelateRule.INSTANCE,
     CalcMergeRule.INSTANCE,
     PythonCalcSplitRule.SPLIT_CONDITION,
     PythonCalcSplitRule.SPLIT_PROJECT,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/SplitPythonConditionFromCorrelateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/SplitPythonConditionFromCorrelateRule.scala
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.logical
+
+import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.plan.hep.HepRelVertex
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelOptUtil}
+import org.apache.calcite.rel.core.JoinRelType
+import org.apache.calcite.rex._
+import org.apache.flink.table.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalCorrelate, FlinkLogicalRel}
+import org.apache.flink.table.plan.util.PythonUtil.containsPythonCall
+import org.apache.flink.table.plan.util.RexDefaultVisitor
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+/**
+  * Rule will split a [[FlinkLogicalCalc]] which is the upstream of a [[FlinkLogicalCorrelate]]
+  * and contains Python Functions in condition into two [[FlinkLogicalCalc]]s. One of the
+  * [[FlinkLogicalCalc]] without python function condition is the upstream of the
+  * [[FlinkLogicalCorrelate]], but the other [[[FlinkLogicalCalc]] with python function conditions
+  * is the downstream of the [[FlinkLogicalCorrelate]]. Currently, only inner join is supported.
+  *
+  * After this rule is applied, there will be no Python Functions in the condition of the upstream
+  * [[FlinkLogicalCalc]].
+  */
+class SplitPythonConditionFromCorrelateRule
+  extends RelOptRule(
+    operand(
+      classOf[FlinkLogicalCorrelate],
+      operand(classOf[FlinkLogicalRel], any),
+      operand(classOf[FlinkLogicalCalc], any)),
+    "SplitPythonConditionFromCorrelateRule") {
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val correlate: FlinkLogicalCorrelate = call.rel(0).asInstanceOf[FlinkLogicalCorrelate]
+    val right: FlinkLogicalCalc = call.rel(2).asInstanceOf[FlinkLogicalCalc]
+    val joinType: JoinRelType = correlate.getJoinType
+    joinType == JoinRelType.INNER && containsPythonFunctionCondition(right)
+  }
+
+  private def containsPythonFunctionCondition(calc: FlinkLogicalCalc): Boolean = {
+    val program = calc.getProgram
+    val conditionExistPythonFunction = Option(program.getCondition)
+      .map(program.expandLocalRef)
+      .exists(containsPythonCall)
+    if (conditionExistPythonFunction) {
+      true
+    } else {
+      val child = calc.getInput.asInstanceOf[HepRelVertex].getCurrentRel
+      child match {
+        case calc: FlinkLogicalCalc => containsPythonFunctionCondition(calc)
+        case _ => false
+      }
+    }
+  }
+
+  private def getMergedCalc(calc: FlinkLogicalCalc): FlinkLogicalCalc = {
+    val child = calc.getInput.asInstanceOf[HepRelVertex].getCurrentRel
+    child match {
+      case logicalCalc: FlinkLogicalCalc =>
+        val bottomCalc = getMergedCalc(logicalCalc)
+        val topCalc = calc
+        val topProgram: RexProgram = topCalc.getProgram
+        val mergedProgram: RexProgram = RexProgramBuilder
+          .mergePrograms(
+            topCalc.getProgram,
+            bottomCalc.getProgram,
+            topCalc.getCluster.getRexBuilder)
+        assert(mergedProgram.getOutputRowType eq topProgram.getOutputRowType)
+        topCalc.copy(topCalc.getTraitSet, bottomCalc.getInput, mergedProgram)
+          .asInstanceOf[FlinkLogicalCalc]
+      case _ =>
+        calc
+    }
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val correlate: FlinkLogicalCorrelate = call.rel(0).asInstanceOf[FlinkLogicalCorrelate]
+    val right: FlinkLogicalCalc = call.rel(2).asInstanceOf[FlinkLogicalCalc]
+    val rexBuilder = call.builder().getRexBuilder
+    val mergedCalc = getMergedCalc(right)
+    val mergedCalcProgram = mergedCalc.getProgram
+    val input = mergedCalc.getInput
+
+    val correlateFilters = RelOptUtil
+      .conjunctions(mergedCalcProgram.getCondition)
+      .map(_.asInstanceOf[RexLocalRef])
+      .map(mergedCalcProgram.expandLocalRef)
+    val remainingFilters = correlateFilters.filter(!containsPythonCall(_))
+
+    val bottomCalcCondition = RexUtil.composeConjunction(rexBuilder, remainingFilters)
+    val newBottomCalc = new FlinkLogicalCalc(
+      mergedCalc.getCluster,
+      mergedCalc.getTraitSet,
+      input,
+      RexProgram.create(
+        input.getRowType,
+        mergedCalcProgram.getProjectList,
+        bottomCalcCondition,
+        mergedCalc.getRowType,
+        rexBuilder))
+
+    val newCorrelate = new FlinkLogicalCorrelate(
+      correlate.getCluster,
+      correlate.getTraitSet,
+      correlate.getLeft,
+      newBottomCalc,
+      correlate.getCorrelationId,
+      correlate.getRequiredColumns,
+      correlate.getJoinType)
+
+    val inputRefRewriter = new InputRefRewriter(
+      correlate.getRowType.getFieldCount - mergedCalc.getRowType.getFieldCount)
+
+    val pythonFilters = correlateFilters
+      .map(_.accept(inputRefRewriter))
+      .filter(containsPythonCall)
+    val topCalcCondition = RexUtil.composeConjunction(rexBuilder, pythonFilters)
+
+    val rexProgram = new RexProgramBuilder(newCorrelate.getRowType, rexBuilder).getProgram
+    val newTopCalc = new FlinkLogicalCalc(
+      newCorrelate.getCluster,
+      newCorrelate.getTraitSet,
+      newCorrelate,
+      RexProgram.create(
+        newCorrelate.getRowType,
+        rexProgram.getExprList,
+        topCalcCondition,
+        newCorrelate.getRowType,
+        rexBuilder))
+
+    call.transformTo(newTopCalc)
+  }
+}
+
+/**
+  * Because the inputRef is from the upstream calc node of the correlate node,
+  * so after the inputRef is pushed to the downstream calc node of the correlate
+  * node, the inputRef need to rewrite the index.
+  *
+  * @param offset the start offset of the inputRef in the downstream calc.
+  */
+private class InputRefRewriter(offset: Int)
+  extends RexDefaultVisitor[RexNode] {
+
+  override def visitInputRef(inputRef: RexInputRef): RexNode = {
+    new RexInputRef(inputRef.getIndex + offset, inputRef.getType)
+  }
+
+  override def visitCall(call: RexCall): RexNode = {
+    call.clone(call.getType, call.getOperands.asScala.map(_.accept(this)))
+  }
+
+  override def visitNode(rexNode: RexNode): RexNode = rexNode
+}
+
+object SplitPythonConditionFromCorrelateRule {
+  val INSTANCE: SplitPythonConditionFromCorrelateRule = new SplitPythonConditionFromCorrelateRule
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/SplitPythonConditionFromCorrelateRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/SplitPythonConditionFromCorrelateRuleTest.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.runtime.utils.JavaUserDefinedScalarFunctions.PythonScalarFunction
+import org.apache.flink.table.utils.TableTestUtil.{streamTableNode, term, unaryNode}
+import org.apache.flink.table.utils.{TableFunc2, TableTestBase}
+import org.junit.Test
+
+class SplitPythonConditionFromCorrelateRuleTest extends TableTestBase {
+
+  @Test
+  def testPythonFunctionInCorrelateCondition(): Unit = {
+    val util = streamTestUtil()
+    val func = new TableFunc2
+    val pyFunc = new PythonScalarFunction("pyFunc")
+    val table = util.addTable[(Int, Int, String)]("MyTable", 'a, 'b, 'c)
+
+    val result = table
+      .joinLateral(func('c) as ('s, 'l), 'l === 'a && 'c === 's && pyFunc('l, 'l) === 2)
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      unaryNode(
+        "DataStreamPythonCalc",
+        unaryNode(
+          "DataStreamCorrelate",
+          streamTableNode(table),
+          term("invocation",
+            "org$apache$flink$table$utils$TableFunc2$23cdbf205566c9600253be74cab2763e($2)"),
+          term("correlate", "table(TableFunc2(c))"),
+          term("select", "a", "b", "c", "s", "l"),
+          term("rowType",
+            "RecordType(INTEGER a, INTEGER b, VARCHAR(65536) c, VARCHAR(65536) s, INTEGER l)"),
+          term("joinType", "INNER"),
+          term("condition", "true")
+        ),
+        term("select", "a", "b", "c", "s", "l", "pyFunc(l, l) AS f0")
+      ),
+      term("select", "a", "b", "c", "s", "l"),
+      term("where", "AND(=(f0, 2), AND(=(l, a), =(c, s)))")
+    )
+
+    util.verifyTable(result, expected)
+  }
+}


### PR DESCRIPTION
10033