### PR TITLE
[FLINK-11196] Extend S3 EntropyInjector to use key replacement (instead of key removal) when creating checkpoint metadata files.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjectingFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjectingFileSystem.java
@@ -43,6 +43,12 @@ public interface EntropyInjectingFileSystem {
 	String getEntropyInjectionKey();
 
 	/**
+	 * Gets the replacement string for the entropy key when creating files that do not require
+	 * entropy injection (e.g. checkpoint metadata files).
+	 */
+	String getEntropyKeyReplacement();
+
+	/**
 	 * Creates a string with random entropy to be injected into a path.
 	 */
 	String generateEntropy();

--- a/flink-core/src/test/java/org/apache/flink/testutils/EntropyInjectingTestFileSystem.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/EntropyInjectingTestFileSystem.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.testutils;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.EntropyInjectingFileSystem;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystemFactory;
@@ -33,11 +34,18 @@ public class EntropyInjectingTestFileSystem extends LocalFileSystem implements E
 
 	public static final String ENTROPY_INJECTION_KEY = "_entropy_";
 
+	public static final String ENTROPY_KEY_REPLACEMENT = "";
+
 	public static final String ENTROPY = "_resolved_";
 
 	@Override
 	public String getEntropyInjectionKey() {
 		return ENTROPY_INJECTION_KEY;
+	}
+
+	@Override
+	public String getEntropyKeyReplacement() {
+		return ENTROPY_KEY_REPLACEMENT;
 	}
 
 	@Override
@@ -50,6 +58,10 @@ public class EntropyInjectingTestFileSystem extends LocalFileSystem implements E
 		@Override
 		public String getScheme() {
 			return "test-entropy";
+		}
+
+		@Override
+		public void configure(final Configuration config) {
 		}
 
 		@Override

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/FlinkS3FileSystem.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/FlinkS3FileSystem.java
@@ -48,6 +48,8 @@ public class FlinkS3FileSystem extends HadoopFileSystem implements EntropyInject
 	@Nullable
 	private final String entropyInjectionKey;
 
+	private final String entropyKeyReplacement;
+
 	private final int entropyLength;
 
 	// ------------------- Recoverable Writer Parameters -------------------
@@ -75,13 +77,15 @@ public class FlinkS3FileSystem extends HadoopFileSystem implements EntropyInject
 	 * <p>This constructor additionally configures the entropy injection for the file system.
 	 *
 	 * @param hadoopS3FileSystem The Hadoop FileSystem that will be used under the hood.
-	 * @param entropyInjectionKey The substring that will be replaced by entropy or removed.
+	 * @param entropyInjectionKey The substring that will be replaced by entropy or by the key replacement.
+	 * @param entropyKeyReplacement The string that will be replace the entropy for files that do not require entropy.
 	 * @param entropyLength The number of random alphanumeric characters to inject as entropy.
 	 */
 	public FlinkS3FileSystem(
 			org.apache.hadoop.fs.FileSystem hadoopS3FileSystem,
 			String localTmpDirectory,
 			@Nullable String entropyInjectionKey,
+			String entropyKeyReplacement,
 			int entropyLength,
 			@Nullable S3AccessHelper s3UploadHelper,
 			long s3uploadPartSize,
@@ -94,6 +98,7 @@ public class FlinkS3FileSystem extends HadoopFileSystem implements EntropyInject
 		}
 
 		this.entropyInjectionKey = entropyInjectionKey;
+		this.entropyKeyReplacement = entropyKeyReplacement;
 		this.entropyLength = entropyLength;
 
 		// recoverable writer parameter configuration initialization
@@ -113,6 +118,11 @@ public class FlinkS3FileSystem extends HadoopFileSystem implements EntropyInject
 	@Override
 	public String getEntropyInjectionKey() {
 		return entropyInjectionKey;
+	}
+
+	@Override
+	public String getEntropyKeyReplacement() {
+		return entropyKeyReplacement;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
@@ -50,21 +50,17 @@ public class FsCheckpointStorageLocation extends FsCheckpointStreamFactory imple
 
 	private final int fileStateSizeThreshold;
 
-	private final int writeBufferSize;
-
 	public FsCheckpointStorageLocation(
 			FileSystem fileSystem,
 			Path checkpointDir,
 			Path sharedStateDir,
 			Path taskOwnedStateDir,
 			CheckpointStorageLocationReference reference,
-			int fileStateSizeThreshold,
-			int writeBufferSize) {
+			int fileStateSizeThreshold) {
 
-		super(fileSystem, checkpointDir, sharedStateDir, fileStateSizeThreshold, writeBufferSize);
+		super(fileSystem, checkpointDir, sharedStateDir, fileStateSizeThreshold);
 
 		checkArgument(fileStateSizeThreshold >= 0);
-		checkArgument(writeBufferSize >= 0);
 
 		this.fileSystem = checkNotNull(fileSystem);
 		this.checkpointDirectory = checkNotNull(checkpointDir);
@@ -73,11 +69,10 @@ public class FsCheckpointStorageLocation extends FsCheckpointStreamFactory imple
 		this.reference = checkNotNull(reference);
 
 		// the metadata file should not have entropy in its path
-		Path metadataDir = EntropyInjector.removeEntropyMarkerIfPresent(fileSystem, checkpointDir);
+		Path metadataDir = EntropyInjector.replaceEntropyMarkerIfPresent(fileSystem, checkpointDir);
 
 		this.metadataFilePath = new Path(metadataDir, AbstractFsCheckpointStorage.METADATA_FILE_NAME);
 		this.fileStateSizeThreshold = fileStateSizeThreshold;
-		this.writeBufferSize = writeBufferSize;
 	}
 
 	// ------------------------------------------------------------------------
@@ -135,7 +130,6 @@ public class FsCheckpointStorageLocation extends FsCheckpointStreamFactory imple
 				", metadataFilePath=" + metadataFilePath +
 				", reference=" + reference +
 				", fileStateSizeThreshold=" + fileStateSizeThreshold +
-				", writeBufferSize=" + writeBufferSize +
 				'}';
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.assertThat;
 public class FsStateBackendEntropyTest {
 
 	static final String ENTROPY_MARKER = "__ENTROPY__";
+	static final String ENTROPY_REPLACEMENT = "+REPLACEMENT+";
 	static final String RESOLVED_MARKER = "+RESOLVED+";
 
 	@Rule
@@ -57,11 +58,10 @@ public class FsStateBackendEntropyTest {
 		final Path checkpointDir = new Path(Path.fromLocalFile(tmp.newFolder()), ENTROPY_MARKER + "/checkpoints");
 		final String checkpointDirStr = checkpointDir.toString();
 
-		final FsCheckpointStorage storage = new FsCheckpointStorage(
-				fs, checkpointDir, null, new JobID(), 1024, 4096);
-		storage.initializeBaseLocations();
+		FsCheckpointStorage storage = new FsCheckpointStorage(
+				fs, checkpointDir, null, new JobID(), 1024);
 
-		final FsCheckpointStorageLocation location = (FsCheckpointStorageLocation)
+		FsCheckpointStorageLocation location = (FsCheckpointStorageLocation)
 				storage.initializeLocationForCheckpoint(96562);
 
 		assertThat(location.getCheckpointDirectory().toString(), startsWith(checkpointDirStr));
@@ -114,6 +114,11 @@ public class FsStateBackendEntropyTest {
 		@Override
 		public String getEntropyInjectionKey() {
 			return ENTROPY_MARKER;
+		}
+
+		@Override
+		public String getEntropyKeyReplacement() {
+			return ENTROPY_REPLACEMENT;
 		}
 
 		@Override


### PR DESCRIPTION
7333